### PR TITLE
Fix label rendering by manually supplying layer order

### DIFF
--- a/oregon-fire/data/maptime.tm2/fire.mss
+++ b/oregon-fire/data/maptime.tm2/fire.mss
@@ -6,6 +6,7 @@
   marker-allow-overlap: true;
   marker-opacity: 0.3;
   marker-comp-op: hard-light;
+  marker-ignore-placement: true;
 
   [year >= 2014] {
     marker-width: 6;

--- a/oregon-fire/data/maptime.tm2/project.xml
+++ b/oregon-fire/data/maptime.tm2/project.xml
@@ -1154,6 +1154,50 @@
     <StyleName>bridge-fill</StyleName>
     <StyleName>bridge</StyleName>  </Layer>
 
+<Style name="fires" filter-mode="first">
+  <Rule>
+    <MaxScaleDenominator>400000</MaxScaleDenominator>
+    <Filter>([year] &gt;= 2014) and ([cause] = 'lightning')</Filter>
+    <MarkersSymbolizer width="10" opacity="0.5" fill="#000000" file="flame.svg" stroke-width="0" allow-overlap="true" comp-op="hard-light" ignore-placement="true" />
+  </Rule>
+  <Rule>
+    <MinScaleDenominator>400000</MinScaleDenominator>
+    <Filter>([year] &gt;= 2014) and ([cause] = 'lightning')</Filter>
+    <MarkersSymbolizer fill="#000000" opacity="0.5" width="6" file="flame.svg" stroke-width="0" allow-overlap="true" comp-op="hard-light" ignore-placement="true" />
+  </Rule>
+  <Rule>
+    <MaxScaleDenominator>400000</MaxScaleDenominator>
+    <Filter>([year] &gt;= 2014)</Filter>
+    <MarkersSymbolizer width="10" opacity="0.5" file="flame.svg" fill="#ff4500" stroke-width="0" allow-overlap="true" comp-op="hard-light" ignore-placement="true" />
+  </Rule>
+  <Rule>
+    <MinScaleDenominator>400000</MinScaleDenominator>
+    <Filter>([year] &gt;= 2014)</Filter>
+    <MarkersSymbolizer width="6" file="flame.svg" fill="#ff4500" stroke-width="0" allow-overlap="true" opacity="0.3" comp-op="hard-light" ignore-placement="true" />
+  </Rule>
+  <Rule>
+    <MaxScaleDenominator>400000</MaxScaleDenominator>
+    <Filter>([cause] = 'lightning')</Filter>
+    <MarkersSymbolizer opacity="0.5" width="6" fill="#000000" file="flame.svg" stroke-width="0" allow-overlap="true" comp-op="hard-light" ignore-placement="true" />
+  </Rule>
+  <Rule>
+    <MinScaleDenominator>400000</MinScaleDenominator>
+    <Filter>([cause] = 'lightning')</Filter>
+    <MarkersSymbolizer fill="#000000" opacity="0.5" file="flame.svg" width="3" stroke-width="0" allow-overlap="true" comp-op="hard-light" ignore-placement="true" />
+  </Rule>
+  <Rule>
+    <MaxScaleDenominator>400000</MaxScaleDenominator>
+    <MarkersSymbolizer opacity="0.5" width="6" file="flame.svg" fill="#ff4500" stroke-width="0" allow-overlap="true" comp-op="hard-light" ignore-placement="true" />
+  </Rule>
+  <Rule>
+    <MinScaleDenominator>400000</MinScaleDenominator>
+    <MarkersSymbolizer file="flame.svg" width="3" fill="#ff4500" stroke-width="0" allow-overlap="true" opacity="0.3" comp-op="hard-light" ignore-placement="true" />
+  </Rule>
+</Style>
+<Layer name="fires"
+  srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
+    <StyleName>fires</StyleName>  </Layer>
+
 <Style name="admin" filter-mode="first">
   <Rule>
     <MaxScaleDenominator>3000000</MaxScaleDenominator>
@@ -3484,49 +3528,5 @@
 <Layer name="housenum_label"
   srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
       </Layer>
-
-<Style name="fires" filter-mode="first">
-  <Rule>
-    <MaxScaleDenominator>400000</MaxScaleDenominator>
-    <Filter>([year] &gt;= 2014) and ([cause] = 'lightning')</Filter>
-    <MarkersSymbolizer width="10" opacity="0.5" fill="#000000" file="flame.svg" stroke-width="0" allow-overlap="true" comp-op="hard-light" />
-  </Rule>
-  <Rule>
-    <MinScaleDenominator>400000</MinScaleDenominator>
-    <Filter>([year] &gt;= 2014) and ([cause] = 'lightning')</Filter>
-    <MarkersSymbolizer fill="#000000" opacity="0.5" width="6" file="flame.svg" stroke-width="0" allow-overlap="true" comp-op="hard-light" />
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>400000</MaxScaleDenominator>
-    <Filter>([year] &gt;= 2014)</Filter>
-    <MarkersSymbolizer width="10" opacity="0.5" file="flame.svg" fill="#ff4500" stroke-width="0" allow-overlap="true" comp-op="hard-light" />
-  </Rule>
-  <Rule>
-    <MinScaleDenominator>400000</MinScaleDenominator>
-    <Filter>([year] &gt;= 2014)</Filter>
-    <MarkersSymbolizer width="6" file="flame.svg" fill="#ff4500" stroke-width="0" allow-overlap="true" opacity="0.3" comp-op="hard-light" />
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>400000</MaxScaleDenominator>
-    <Filter>([cause] = 'lightning')</Filter>
-    <MarkersSymbolizer opacity="0.5" width="6" fill="#000000" file="flame.svg" stroke-width="0" allow-overlap="true" comp-op="hard-light" />
-  </Rule>
-  <Rule>
-    <MinScaleDenominator>400000</MinScaleDenominator>
-    <Filter>([cause] = 'lightning')</Filter>
-    <MarkersSymbolizer fill="#000000" opacity="0.5" file="flame.svg" width="3" stroke-width="0" allow-overlap="true" comp-op="hard-light" />
-  </Rule>
-  <Rule>
-    <MaxScaleDenominator>400000</MaxScaleDenominator>
-    <MarkersSymbolizer opacity="0.5" width="6" file="flame.svg" fill="#ff4500" stroke-width="0" allow-overlap="true" comp-op="hard-light" />
-  </Rule>
-  <Rule>
-    <MinScaleDenominator>400000</MinScaleDenominator>
-    <MarkersSymbolizer file="flame.svg" width="3" fill="#ff4500" stroke-width="0" allow-overlap="true" opacity="0.3" comp-op="hard-light" />
-  </Rule>
-</Style>
-<Layer name="fires"
-  srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over">
-    <StyleName>fires</StyleName>  </Layer>
 
 </Map>

--- a/oregon-fire/data/maptime.tm2/project.yml
+++ b/oregon-fire/data/maptime.tm2/project.yml
@@ -1,27 +1,49 @@
-_prefs: 
+_prefs:
   saveCenter: false
-_properties: 
-  bridge: 
+_properties:
+  bridge:
     "group-by": layer
 attribution: "<a href='https://www.mapbox.com/about/maps/' target='_blank'>&copy; Mapbox &copy; OpenStreetMap</a> <a class='mapbox-improve-map' href='https://www.mapbox.com/map-feedback/' target='_blank'>Improve this map</a>"
-bounds: 
+bounds:
   - -180
   - -85.0511
   - 180
   - 85.0511
-center: 
+center:
   - -123.4644
   - 43.1731
   - 6
 description: Oregon fire data
 format: "png8:m=h"
 interactivity_layer: ''
-layers: null
+layers:
+  - landuse
+  - waterway
+  - water
+  - aeroway
+  - barrier_line
+  - building
+  - landuse_overlay
+  - tunnel
+  - road
+  - bridge
+  - fires
+  - admin
+  - country_label_line
+  - country_label
+  - marine_label
+  - state_label
+  - place_label
+  - water_label
+  - poi_label
+  - road_label
+  - waterway_label
+  - housenum_label
 maxzoom: 17
 minzoom: 6
 name: Maptime Oregon Fire
 source: "mapbox:///mapbox.mapbox-streets-v5,caged.aa3fadad"
-styles: 
+styles:
   - style.mss
   - labels.mss
   - roads.mss

--- a/oregon-fire/script.md
+++ b/oregon-fire/script.md
@@ -156,6 +156,7 @@ Add flame.svg to the inside of your mapbox studio project file.
  ```
 
  ![](./images/step-7.png)
+ 
 
 ### What next? Things you can do at home
 * If we get done too fast, move on to talk about adjusting zoom levels.


### PR DESCRIPTION
This fixes the label overlapping issue. I tweaked the layer order because I wanted the fire to appear over roads, bridges, etc. 

![screen shot 2015-07-06 at 6 13 57 pm](https://cloud.githubusercontent.com/assets/25/8536799/d2f857e0-240a-11e5-9b9b-63ef34a1a3c9.png)

/cc @geografa 
